### PR TITLE
Issue/179: fix: Skill abilities now correctly read from document

### DIFF
--- a/business/document/item/transient-skill.mjs
+++ b/business/document/item/transient-skill.mjs
@@ -364,6 +364,8 @@ export default class TransientSkill extends TransientBaseItem {
       
     const result = [];
     for (const abilityId in abilitiesOnDocument) {
+      if (abilitiesOnDocument.hasOwnProperty(abilityId) !== true) continue;
+
       const dto = abilitiesOnDocument[abilityId];
 
       const damage = [];


### PR DESCRIPTION
* Turns out there was a missing `hasOwnProperty` check inside the `TransientSkill._getSkillAbilities` method.