### PR TITLE
Issue/187: refactor/fix: Skill chat message no longer throws errors

### DIFF
--- a/presentation/component/button-toggle-visibility/button-toggle-visibility-viewmodel.mjs
+++ b/presentation/component/button-toggle-visibility/button-toggle-visibility-viewmodel.mjs
@@ -57,15 +57,17 @@ export default class ButtonToggleVisibilityViewModel extends ButtonViewModel {
   /**
    * @param {String | undefined} args.id Optional. Unique ID of this view model instance. 
    * 
-   * @param {Object} args.target The target object to affect. 
+   * @param {Object | undefined} args.target The target object to affect. 
    * @param {Function | String | undefined} args.callback Optional. Defines an asynchronous callback that is invoked upon completion of the button's own callback. 
    * @param {Boolean | undefined} args.isEditable Optional. If true, will be interactible. 
    * @param {String | undefined} args.localizableTitle Optional. The localizable title (tooltip). 
    * 
-   * @param {String} args.visGroup Id or name to group the visiblity of elements by. 
+   * @param {String | undefined} args.visGroup Id or name to group the visiblity of elements by. 
    * Expects this id to be defined as a data-attribute. 
-   * E. g. '\<div data-vis-group="1A2b3F4E"\>My content\</div\>'
+   * 
+   * E. g. `<div data-vis-group="1A2b3F4E">My content</div>`. 
    * @param {Boolean | undefined} args.toggleSelf Optional. If true, the button will also toggle visibility on itself. 
+   * * Default `false`. 
    */
   constructor(args = {}) {
     super(args);

--- a/presentation/sheet/item/skill-ability/skill-ability-table-viewmodel.mjs
+++ b/presentation/sheet/item/skill-ability/skill-ability-table-viewmodel.mjs
@@ -7,7 +7,6 @@ import SortableListViewModel from "../../../component/sortable-list/sortable-lis
 import { TEMPLATES } from "../../../templatePreloader.mjs"
 import ViewModelFactory from "../../../view-model/view-model-factory.mjs"
 import ViewModel from "../../../view-model/view-model.mjs"
-import SkillAbilityChatMessageViewModel from "./skill-ability-chat-message-viewmodel.mjs"
 import SkillAbilityListItemViewModel from "./skill-ability-list-item-viewmodel.mjs"
 
 export default class SkillAbilityTableViewModel extends ViewModel {
@@ -37,12 +36,6 @@ export default class SkillAbilityTableViewModel extends ViewModel {
     // Immediately write view state. 
     this.writeAllViewState();
   }
-
-  /**
-   * @type {Boolean}
-   * @readonly
-   */
-  oneColumn = false;
 
   /**
    * @type {String}
@@ -77,7 +70,6 @@ export default class SkillAbilityTableViewModel extends ViewModel {
    * @param {Boolean | undefined} args.isOwner If true, the current user is the owner of the represented document. 
    * 
    * @param {TransientSkill} args.document
-   * @param {Boolean | undefined} args.oneColumn
    * @param {String | undefined} args.visGroupId
    * @param {Boolean | undefined} args.skillAbilitiesInitiallyVisible
    */
@@ -89,7 +81,6 @@ export default class SkillAbilityTableViewModel extends ViewModel {
 
     // Own properties.
     this.document = args.document;
-    this.oneColumn = args.oneColumn ?? false;
     this.visGroupId = args.visGroupId ?? createUUID();
     this._skillAbilitiesInitiallyVisible = args.skillAbilitiesInitiallyVisible ?? false;
 
@@ -110,7 +101,7 @@ export default class SkillAbilityTableViewModel extends ViewModel {
         listName: "abilities",
       }),
       listItemViewModels: this.abilities,
-      listItemTemplate: thiz.oneColumn === true ? TEMPLATES.SKILL_ABILITY_CHAT_MESSAGE : TEMPLATES.SKILL_ABILITY_LIST_ITEM,
+      listItemTemplate: TEMPLATES.SKILL_ABILITY_LIST_ITEM,
       vmBtnAddItem: factory.createVmBtnAdd({
         id: "vmBtnAdd",
         target: thiz.document,
@@ -173,7 +164,7 @@ export default class SkillAbilityTableViewModel extends ViewModel {
   }
 
   /**
-   * @returns {Array<SkillAbilityChatMessageViewModel> | Array<SkillAbilityListItemViewModel>}
+   * @returns {Array<SkillAbilityListItemViewModel>}
    * 
    * @private
    */
@@ -181,26 +172,13 @@ export default class SkillAbilityTableViewModel extends ViewModel {
     const result = [];
     const skillAbilities = this.document.abilities;
     for (const skillAbility of skillAbilities) {
-      let vm = undefined;
-
-      if (this.oneColumn === true) {
-        vm = new SkillAbilityChatMessageViewModel({
-          id: skillAbility.id,
-          isEditable: this.isEditable,
-          isSendable: this.isSendable,
-          isOwner: this.isOwner,
-          skillAbility: skillAbility,
-        })
-      } else {
-        vm = new SkillAbilityListItemViewModel({
-          id: skillAbility.id,
-          isEditable: this.isEditable,
-          isSendable: this.isSendable,
-          isOwner: this.isOwner,
-          skillAbility: skillAbility,
-        });
-      }
-
+      const vm = new SkillAbilityListItemViewModel({
+        id: skillAbility.id,
+        isEditable: this.isEditable,
+        isSendable: this.isSendable,
+        isOwner: this.isOwner,
+        skillAbility: skillAbility,
+      });
       result.push(vm);
       this[vm._id] = vm;
     }

--- a/presentation/sheet/item/skill/skill-chat-message-viewmodel.mjs
+++ b/presentation/sheet/item/skill/skill-chat-message-viewmodel.mjs
@@ -1,9 +1,10 @@
 import { ATTRIBUTES } from "../../../../business/ruleset/attribute/attributes.mjs"
 import { validateOrThrow } from "../../../../business/util/validation-utility.mjs"
+import ButtonToggleVisibilityViewModel from "../../../component/button-toggle-visibility/button-toggle-visibility-viewmodel.mjs"
 import LazyRichTextViewModel from "../../../component/lazy-rich-text/lazy-rich-text-viewmodel.mjs"
 import { TEMPLATES } from "../../../templatePreloader.mjs"
 import ViewModel from "../../../view-model/view-model.mjs"
-import SkillAbilityTableViewModel from "../skill-ability/skill-ability-table-viewmodel.mjs"
+import SkillAbilityChatMessageViewModel from "../skill-ability/skill-ability-chat-message-viewmodel.mjs"
 
 export default class SkillChatMessageViewModel extends ViewModel {
   /** @override */
@@ -32,6 +33,23 @@ export default class SkillChatMessageViewModel extends ViewModel {
     const options = ATTRIBUTES.asChoices;
     return options.find(it => { return it.value === this.document.relatedAttribute.name }).localizedValue;
   }
+  
+  /**
+   * @type {String}
+   * @readonly
+   */
+  get templateSkillAbility() { return TEMPLATES.SKILL_ABILITY_CHAT_MESSAGE; }
+
+  /**
+   * @type {Boolean}
+   * @default false
+   */
+  skillAbilitiesInitiallyVisible = false;
+
+  /**
+   * @type {Array<SkillAbilityChatMessageViewModel>}
+   */
+  skillAbilityViewModels = [];
 
   /**
    * @param {String | undefined} args.id Optional. Id used for the HTML element's id and name attributes. 
@@ -50,20 +68,25 @@ export default class SkillChatMessageViewModel extends ViewModel {
     this.contextTemplate = args.contextTemplate ?? "skill-chat-message";
     
     this.document = args.document;
-    
-    // Child view models. 
-    const thiz = this;
+    this.skillAbilityViewModels = this.document.abilities.map(it => it.getChatViewModel());
 
-    this.vmSkillAbilityTable = new SkillAbilityTableViewModel({
-      id: "vmSkillAbilityTable",
-      parent: thiz,
-      isEditable: thiz.isEditable,
-      isSendable: thiz.isSendable,
-      isOwner: thiz.isOwner,
-      document: thiz.document,
-      skillAbilitiesInitiallyVisible: false,
-      oneColumn: true,
-      visGroupId: thiz.visGroupId,
+    this.vmBtnToggleVisibilityExpand = new ButtonToggleVisibilityViewModel({
+      id: "vmBtnToggleVisibilityExpand",
+      parent: this,
+      isEditable: true,
+      isSendable: this.isSendable,
+      isOwner: this.isOwner,
+      visGroup: `${this.id}-abilities`,
+      toggleSelf: true,
+    });
+    this.vmBtnToggleVisibilityCollapse = new ButtonToggleVisibilityViewModel({
+      id: "vmBtnToggleVisibilityCollapse",
+      parent: this,
+      isEditable: true,
+      isSendable: this.isSendable,
+      isOwner: this.isOwner,
+      visGroup: `${this.id}-abilities`,
+      toggleSelf: true,
     });
     this.vmLazyDescription = new LazyRichTextViewModel({
       id: "vmLazyDescription",

--- a/presentation/sheet/item/skill/skill-chat-message.hbs
+++ b/presentation/sheet/item/skill/skill-chat-message.hbs
@@ -38,5 +38,22 @@ cssClass: {undefined | String}
     {{> lazyRichText viewModel=viewModel.vmLazyDescription}}
   </div>
   {{!-- Skill Abilites --}}
-  {{> "systems/ambersteel/presentation/sheet/item/skill-ability/skill-ability-table.hbs" viewModel=viewModel.vmSkillAbilityTable cssClass=(ifThenElse viewModel.hasAbilities "" "hidden") }}
+  {{#if viewModel.hasAbilities}}
+    {{!-- {{> "systems/ambersteel/presentation/sheet/item/skill-ability/skill-ability-table.hbs" viewModel=viewModel.vmSkillAbilityTable cssClass=(ifThenElse viewModel.hasAbilities "" "hidden") }} --}}
+    <div data-vis-group="{{viewModel.id}}-abilities" class="{{#if viewModel.skillAbilitiesInitiallyVisible}}{{else}}hidden{{/if}}">
+    {{#with viewModel.templateSkillAbility as | template |}}
+    {{#each ../viewModel.skillAbilityViewModels as |vm index|}}
+      {{> (template) viewModel=vm}}
+    {{/each}}
+    {{/with}}
+    </div>
+    <div class="line-height">
+      {{#> buttonToggleVisibility viewModel=viewModel.vmBtnToggleVisibilityExpand fill=true cssClass=(ifThenElse viewModel.skillAbilitiesInitiallyVisible "hidden" "") }}
+        <i class="fas fa-angle-double-down"></i>
+      {{/buttonToggleVisibility}}
+      {{#> buttonToggleVisibility viewModel=viewModel.vmBtnToggleVisibilityCollapse fill=true cssClass=(ifThenElse viewModel.skillAbilitiesInitiallyVisible "" "hidden") }}
+        <i class="fas fa-angle-double-up"></i>
+      {{/buttonToggleVisibility}}
+    </div>
+  {{/if}}
 </section>

--- a/presentation/sheet/item/skill/skill-item-sheet-viewmodel.mjs
+++ b/presentation/sheet/item/skill/skill-item-sheet-viewmodel.mjs
@@ -110,7 +110,6 @@ export default class SkillItemSheetViewModel extends SkillViewModel {
       isOwner: thiz.isOwner,
       document: thiz.document,
       skillAbilitiesInitiallyVisible: true,
-      oneColumn: false,
       visGroupId: thiz.visGroupId,
     });
   }

--- a/presentation/sheet/item/skill/skill-list-item-viewmodel.mjs
+++ b/presentation/sheet/item/skill/skill-list-item-viewmodel.mjs
@@ -150,7 +150,6 @@ export default class SkillListItemViewModel extends SkillViewModel {
       isOwner: thiz.isOwner,
       document: thiz.document,
       skillAbilitiesInitiallyVisible: false,
-      oneColumn: false,
       visGroupId: thiz.visGroupId,
     });
     this.vmSwIsMagicSchool = factory.createVmBtnToggle({


### PR DESCRIPTION
* Previously, the skill chat message was using the `SortableList` component, but never needed its full functionality. Now, it no longer uses that component, instead embedding the skill ability list directly. This way, there can no longer be any confusion as to the DOM the view model expects.
* The skill ability table no longer supports the `oneColumn` constructor parameter. It is unneeded, as the skill ability table is now always assumed to provide full editability of the skill abilities contained therein.