### PR TITLE
Issue/249

### DIFF
--- a/business/ruleset/health/character-health-state.mjs
+++ b/business/ruleset/health/character-health-state.mjs
@@ -1,0 +1,45 @@
+import { HealthState } from "./health-states.mjs";
+
+/**
+ * Represents a character health state. 
+ * 
+ * @property {String} name Internal name. 
+ * @property {String | undefined} localizableName Localization key. 
+ * @property {String | undefined} icon CSS class of an icon. 
+ * * E. g. `"fas fa-virus"`
+ * @property {Number} limit A limit on how many times this health state may be incurred. 
+ * * `0` implies there is no limit. 
+ * * Minimum is `0`.
+ * @property {Number} intensity The current value. 
+ * * Minimum is `1`.
+*/
+export class CharacterHealthState extends HealthState {
+  /**
+   * @private
+   */
+  _intensity = 0;
+  get intensity() { return this._intensity; }
+  set intensity(value) {
+    this._intensity = Math.max(value, 1);
+  }
+
+  /**
+   * @param {Object} args
+   * @param {String} args.name Internal name. 
+   * @param {String | undefined} args.localizableName Localization key. 
+   * @param {String | undefined} args.icon CSS class of an icon. 
+   * * E. g. `"fas fa-virus"`
+   * @param {Number | undefined} args.limit A limit on how many times this health state may be incurred. 
+   * * `0` implies there is no limit. 
+   * * Default `0`.
+   * * Negative values are clamped to `0`.
+   * @param {Number | undefined} args.intensity The current value. 
+   * * Negative values and `0` are clamped to `1`.
+   * * Default `1`.
+   */
+  constructor(args = {}) {
+    super(args);
+
+    this._intensity = args.intensity ?? 1;
+  }
+}

--- a/business/ruleset/health/health-states.mjs
+++ b/business/ruleset/health/health-states.mjs
@@ -8,14 +8,30 @@ import { validateOrThrow } from "../../util/validation-utility.mjs";
  * @property {String | undefined} localizableName Localization key. 
  * @property {String | undefined} icon CSS class of an icon. 
  * * E. g. `"fas fa-virus"`
-*/
+ * @property {Number} limit A limit on how many times this health state may be incurred. 
+ * * `0` implies there is no limit. 
+ * * Minimum is `0`.
+ */
 export class HealthState {
+  /**
+   * @private
+   */
+  _limit = 0;
+  get limit() { return this._limit; }
+  set limit(value) {
+    this._limit = Math.max(value, 0);
+  }
+
   /**
    * @param {Object} args
    * @param {String} args.name Internal name. 
    * @param {String | undefined} args.localizableName Localization key. 
    * @param {String | undefined} args.icon CSS class of an icon. 
    * * E. g. `"fas fa-virus"`
+   * @param {Number | undefined} args.limit A limit on how many times this health state may be incurred. 
+   * * `0` implies there is no limit. 
+   * * Default `0`.
+   * * Negative values are clamped to `0`.
    */
   constructor(args = {}) {
     validateOrThrow(args, ["name"]);
@@ -23,6 +39,7 @@ export class HealthState {
     this.name = args.name;
     this.localizableName = args.localizableName;
     this.icon = args.icon;
+    this._limit = args.limit ?? 0;
   }
 }
 
@@ -58,74 +75,92 @@ export const HEALTH_STATES = {
   berserk: new HealthState({
     name: "berserk",
     localizableName: "ambersteel.character.health.states.berserk",
+    limit: 1,
   }),
   burning: new HealthState({
     name: "burning",
     localizableName: "ambersteel.character.health.states.burning",
+    limit: 1,
   }),
   bleeding: new HealthState({
     name: "bleeding",
     localizableName: "ambersteel.character.health.states.bleeding",
+    limit: 0,
   }),
   dazed: new HealthState({
     name: "dazed",
     localizableName: "ambersteel.character.health.states.dazed",
+    limit: 1,
   }),
   deathsDoor: new HealthState({
     name: "deathsDoor",
     localizableName: "ambersteel.character.health.states.death",
+    limit: 1,
   }),
   dissolving: new HealthState({
     name: "dissolving",
     localizableName: "ambersteel.character.health.states.dissolving",
+    limit: 1,
   }),
   drugAddicted: new HealthState({
     name: "drugAddicted",
     localizableName: "ambersteel.character.health.states.drugAddicted",
+    limit: 1,
   }),
   electrified: new HealthState({
     name: "electrified",
     localizableName: "ambersteel.character.health.states.electrified",
+    limit: 1,
   }),
   frostbitten: new HealthState({
     name: "frostbitten",
     localizableName: "ambersteel.character.health.states.frostbitten",
+    limit: 2,
   }),
   grappled: new HealthState({
     name: "grappled",
     localizableName: "ambersteel.character.health.states.grappled",
+    limit: 1,
   }),
   hasted: new HealthState({
     name: "hasted",
     localizableName: "ambersteel.character.health.states.hasted",
+    limit: 1,
   }),
   jealous: new HealthState({
     name: "jealous",
     localizableName: "ambersteel.character.health.states.jealous",
+    limit: 1,
   }),
   pacified: new HealthState({
     name: "pacified",
     localizableName: "ambersteel.character.health.states.pacified",
+    limit: 1,
   }),
   poisoned: new HealthState({
     name: "poisoned",
     localizableName: "ambersteel.character.health.states.poisoned",
+    limit: 0,
   }),
   prone: new HealthState({
     name: "prone",
     localizableName: "ambersteel.character.health.states.prone",
+    limit: 1,
   }),
   rooted: new HealthState({
     name: "rooted",
     localizableName: "ambersteel.character.health.states.rooted",
+    limit: 1,
   }),
   terrified: new HealthState({
     name: "terrified",
     localizableName: "ambersteel.character.health.states.terrified",
+    limit: 1,
   }),
   unconscious: new HealthState({
     name: "unconscious",
     localizableName: "ambersteel.character.health.states.unconscious",
+    limit: 1,
   }),
   get asChoices() {
     if (this._asChoices === undefined) {

--- a/presentation/component/input-number-spinner/input-number-spinner-viewmodel.mjs
+++ b/presentation/component/input-number-spinner/input-number-spinner-viewmodel.mjs
@@ -34,6 +34,7 @@ export default class InputNumberSpinnerViewModel extends InputViewModel {
   get hasMax() { return this.max !== undefined; }
 
   /**
+   * @param {Object} args
    * @param {String | undefined} args.id Optional. Unique ID of this view model instance. 
    * 
    * @param {String} args.propertyPath The path used to look up the value. 

--- a/presentation/dialog/settings/health-states/custom-health-state-list-item-viewmodel.mjs
+++ b/presentation/dialog/settings/health-states/custom-health-state-list-item-viewmodel.mjs
@@ -1,4 +1,6 @@
 import { validateOrThrow } from "../../../../business/util/validation-utility.mjs";
+import ObservableField from "../../../../common/observables/observable-field.mjs";
+import InputNumberSpinnerViewModel from "../../../component/input-number-spinner/input-number-spinner-viewmodel.mjs";
 import InputTextFieldViewModel from "../../../component/input-textfield/input-textfield-viewmodel.mjs";
 import { TEMPLATES } from "../../../templatePreloader.mjs";
 import ViewModel from "../../../view-model/view-model.mjs";
@@ -13,33 +15,63 @@ export default class CustomHealthStateListItemViewModel extends ViewModel {
   static get TEMPLATE() { return TEMPLATES.CUSTOM_HEALTH_STATE_LIST_ITEM; }
 
   /**
+   * Returns an object representation of the data. 
+   * 
+   * @type {Object}
+   * @private
+   * @readonly
+   */
+  get state() { return {
+      name: this.stateName.value,
+      limit: this.stateLimit.value,
+    };
+  }
+
+  /**
    * @param {Object} args
    * @param {String | undefined} args.id Unique ID of this view model instance. 
    * @param {Boolean | undefined} args.isEditable If true, input(s) will be in edit mode. If false, input(s) will be in read-only mode.
    * @param {String | undefined} args.contextTemplate Name or path of a template that embeds this input component. 
    * 
-   * @param {String} args.propertyOwner
-   * @param {String} args.propertyPath
+   * @param {String} args.stateName
+   * @param {Number | undefined} args.stateLimit
+   * * Default `0`
    * @param {Function | undefined} args.onChange Callback that is invoked when the value changes. 
-   * * Receives two arguments: 
-   * * * `oldValue: {Any}`
-   * * * `newValue: {Any}`
+   * * Receives one argument: 
+   * * * `state: {Object}`
+   * * * `state.name: {String}`
+   * * * `state.limit: {Number}`
    */
   constructor(args = {}) {
     super(args);
-    validateOrThrow(args, ["propertyOwner", "propertyPath"]);
+    validateOrThrow(args, ["stateName"]);
 
-    this.propertyOwner = args.propertyOwner;
-    this.propertyPath = args.propertyPath;
     this.onChange = args.onChange ?? (() => {});
+
+    this.stateName = new ObservableField({ value: args.stateName})
+    this.stateName.onChange((field, oldValue, newValue) => {
+      this.onChange(this.state);
+    });
+
+    this.stateLimit = new ObservableField({ value: (args.stateLimit ?? 0)})
+    this.stateLimit.onChange((field, oldValue, newValue) => {
+      this.onChange(this.state);
+    });
 
     this.vmName = new InputTextFieldViewModel({
       id: "vmName",
       parent: this,
       isEditable: this.isEditable,
-      propertyOwner: this.propertyOwner,
-      propertyPath: this.propertyPath,
-      onChange: this.onChange,
+      propertyOwner: this,
+      propertyPath: "stateName.value",
+    });
+    this.vmLimit = new InputNumberSpinnerViewModel({
+      id: "vmLimit",
+      parent: this,
+      isEditable: this.isEditable,
+      propertyOwner: this,
+      propertyPath: "stateLimit.value",
+      min: 0,
     });
   }
 }

--- a/presentation/dialog/settings/health-states/custom-health-state-list-item.hbs
+++ b/presentation/dialog/settings/health-states/custom-health-state-list-item.hbs
@@ -2,8 +2,16 @@
 viewModel: CustomHealthStateListItemViewModel
 --}}
 <div class="flex flex-row flex-grow flex-middle">
+  {{!-- Name --}}
   {{#> label showFancyFont=viewModel.showFancyFont}}{{localize "ambersteel.general.name"}}{{/label}}
-  <div class="flex-grow">
+  <span class="flex-grow">
     {{> inputTextField viewModel=viewModel.vmName}}
-  </div>
+  </span>
+  {{!-- Spacer --}}
+  <span class="width-sm"></span>
+  {{!-- Limit --}}
+  {{#> label showFancyFont=viewModel.showFancyFont}}{{localize "ambersteel.character.health.state.limit"}}{{/label}}
+  <span class="width-md">
+    {{> inputNumberSpinner viewModel=viewModel.vmLimit}}
+  </span>
 </div>

--- a/presentation/dialog/settings/health-states/health-states-settings-dialog-viewmodel.mjs
+++ b/presentation/dialog/settings/health-states/health-states-settings-dialog-viewmodel.mjs
@@ -164,12 +164,14 @@ export default class HealthStatesSettingsDialogViewModel extends ViewModel {
     const thiz = this;
 
     for (let index = 0; index < this.stateSettings.custom.length; index++) {
+      const customHealthState = this.stateSettings.custom[index];
       const vm = new CustomHealthStateListItemViewModel({
         id: `name${index}`,
         isEditable: this.isEditable,
-        propertyOwner: this,
-        propertyPath: `stateSettings.custom[${index}]`,
-        onChange: () => {
+        stateName: (customHealthState.name ?? customHealthState),
+        stateLimit: (customHealthState.limit ?? 0),
+        onChange: (state) => {
+          this.stateSettings.custom[index] = state;
           thiz._renderFormApplication();
         }
       });
@@ -194,7 +196,10 @@ export default class HealthStatesSettingsDialogViewModel extends ViewModel {
    * @private
    */
   _onClickAddCustomHealthState() {
-    this.stateSettings.custom.push("New Health State");
+    this.stateSettings.custom.push({
+      name: "New Health State",
+      limit: 0,
+    });
     this._renderFormApplication();
   }
 

--- a/presentation/dialog/settings/health-states/health-states-settings-dialog.hbs
+++ b/presentation/dialog/settings/health-states/health-states-settings-dialog.hbs
@@ -3,11 +3,11 @@ viewModel: HealthStatesSettingsDialogViewModel
 --}}
 <section>
   <div class="sheet-block flex flex-column">
-    <h2>{{localize "ambersteel.settings.healthStates.configureSystemDefaults"}}</h2>
+    {{#> header2 showFancyFont=viewModel.showFancyFont}}{{localize "ambersteel.settings.healthStates.configureSystemDefaults"}}{{/header2}}
     {{> visibilityToggleList viewModel=viewModel.vmVisibilityList}}
   </div>
   <div class="sheet-block flex flex-column">
-    <h2>{{localize "ambersteel.settings.healthStates.configureCustom"}}</h2>
+    {{#> header2 showFancyFont=viewModel.showFancyFont}}{{localize "ambersteel.settings.healthStates.configureCustom"}}{{/header2}}
     {{> simpleList viewModel=viewModel.vmCustomList}}
   </div>
   <div>

--- a/presentation/lang/en.json
+++ b/presentation/lang/en.json
@@ -428,6 +428,11 @@
           "plural": "Scars",
           "singular": "Scar"
         },
+        "state": {
+          "label": "Health State",
+          "intensity": "Intensity",
+          "limit": "Limit"
+        },
         "states": {
           "label": "States",
           "berserk": "Berserk",

--- a/presentation/sheet/actor/part/health/actor-health-states-list-item.hbs
+++ b/presentation/sheet/actor/part/health/actor-health-states-list-item.hbs
@@ -5,6 +5,11 @@ viewModel: {ActorHealthStatesListItemViewModel}
   <span>
     {{> buttonToggle viewModel=viewModel.btnToggle}}
   </span>
+  {{#if viewModel.showIntensity}}
+    <span class="width-md">
+      {{> inputNumberSpinner viewModel=viewModel.vmIntensity}}
+    </span>
+  {{/if}}
   <span class="flex flex-grow pad-l-lg">
     {{#> label showFancyFont=viewModel.showFancyFont}}{{viewModel.localizedLabel}}{{/label}}
   </span>

--- a/presentation/sheet/actor/part/health/actor-health-states-viewmodel.mjs
+++ b/presentation/sheet/actor/part/health/actor-health-states-viewmodel.mjs
@@ -107,7 +107,7 @@ export default class ActorHealthStatesViewModel extends ViewModel {
       const isVisible = stateSettings.hidden.find(stateName => state.name === stateName) === undefined;
       if (isVisible === true) {
         const vm = new ActorHealthStatesListItemViewModel({
-          id: state.name,
+          id: this.getSanitizedStateName(state.name),
           parent: this,
           document: this.document,
           isEditable: this.isEditable,
@@ -121,5 +121,19 @@ export default class ActorHealthStatesViewModel extends ViewModel {
         this.stateViewModels.push(vm);
       }
     }
+  }
+
+  /**
+   * "Sanitizes" the given state name, by removing spaces and converting to lower-case 
+   * and returns the result. 
+   * 
+   * @param {String} stateName 
+   * 
+   * @returns {String}
+   * 
+   * @private
+   */
+  getSanitizedStateName(stateName) {
+    return stateName.replace(/ /g, "-").toLowerCase();
   }
 }

--- a/presentation/sheet/actor/part/health/actor-health-states-viewmodel.mjs
+++ b/presentation/sheet/actor/part/health/actor-health-states-viewmodel.mjs
@@ -1,3 +1,4 @@
+import { CharacterHealthState } from "../../../../../business/ruleset/health/character-health-state.mjs";
 import { HealthState, HEALTH_STATES } from "../../../../../business/ruleset/health/health-states.mjs";
 import LoadHealthStatesSettingUseCase from "../../../../../business/use-case/load-health-states-setting-use-case.mjs";
 import { validateOrThrow } from "../../../../../business/util/validation-utility.mjs";
@@ -46,17 +47,48 @@ export default class ActorHealthStatesViewModel extends ViewModel {
 
     this.stateViewModels = [];
     
+    const characterHealthStates = this.document.health.states;
+
+    // Get all custom-defined health states. 
+    // If a particular health state is already on the character, then that instance 
+    // will be taken, instead of a new "blank" instance. 
     const stateSettings = new LoadHealthStatesSettingUseCase().invoke();
+    const customHealthStates = stateSettings.custom.map((customDefinition) => {
+      // For backwards-compatibility, also attempt to use the `customDefinition` directly - 
+      // in older versions, custom health states were defined as a string, instead of object. 
+      const characterHealthState = characterHealthStates.find(it => it.name === (customDefinition.name ?? customDefinition));
+      if (characterHealthState === undefined) {
+        return new CharacterHealthState({
+          name: customDefinition.name ?? customDefinition,
+          localizableName: customDefinition.name ?? customDefinition,
+          limit: customDefinition.limit ?? 0,
+          intensity: 0,
+        });
+      } else {
+        return characterHealthState;
+      }
+    });
+
+    // Get all system-defined health states. 
+    // If a particular health state is already on the character, then that instance 
+    // will be taken, instead of a new "blank" instance. 
+    const systemHealthStates = HEALTH_STATES.asArray.map((healthState) => {
+      const characterHealthState = characterHealthStates.find(it => it.name === healthState.name);
+      if (characterHealthState === undefined) {
+        return new CharacterHealthState({
+          name: healthState.name,
+          localizableName: healthState.localizableName,
+          limit: healthState.limit,
+          intensity: 0,
+        });
+      } else {
+        return characterHealthState;
+      }
+    });
 
     // Combine the system default states with the custom states in a single list. 
-    const states = HEALTH_STATES.asArray.concat(
-      stateSettings.custom.map(customName => 
-        new HealthState({
-          name: customName,
-          localizableName: customName,
-        })
-      )
-    );
+    const states = systemHealthStates.concat(customHealthStates);
+
     // Sort alphabetically. 
     states.sort((a, b) => {
       const lowerA = a.name.toLowerCase();
@@ -72,7 +104,8 @@ export default class ActorHealthStatesViewModel extends ViewModel {
     });
 
     for (const state of states) {
-      if (stateSettings.hidden.find(stateName => state.name === stateName) === undefined) {
+      const isVisible = stateSettings.hidden.find(stateName => state.name === stateName) === undefined;
+      if (isVisible === true) {
         const vm = new ActorHealthStatesListItemViewModel({
           id: state.name,
           parent: this,
@@ -82,6 +115,8 @@ export default class ActorHealthStatesViewModel extends ViewModel {
           isOwner: this.isOwner,
           localizedLabel: game.i18n.localize(state.localizableName),
           stateName: state.name,
+          stateIntensity: state.intensity,
+          stateLimit: state.limit,
         });
         this.stateViewModels.push(vm);
       }


### PR DESCRIPTION
* This work adheres to a new dogma in regards to view model data change reactivity - previously, input components (such as a text field, number spinner, drop-down and so on) would directly modify a `TransientDocument`'s data. However, this made it very difficult to perform intermediary data transformations. Now, the new approach is to instead have these input components modify data on their owning view model instance. The data changed is kept behind `ObservableField`s, which offer an API for reacting to the data change and for transforming the data, before it is persisted. This new approach shall introduce a much stronger decoupling of the view model data and the actual data, which will make it easier to work with both.
* Custom health states can now also have a limit defined.