### PR TITLE
Isse/320

### DIFF
--- a/business/migration/abstract-migrator.mjs
+++ b/business/migration/abstract-migrator.mjs
@@ -50,7 +50,7 @@ export default class AbstractMigrator {
    * @returns {Boolean} True, if this migrator can be applied to the current world system version. 
    */
   isApplicable() {
-    const version = WorldSystemVersion.version;
+    const version = WorldSystemVersion.get();
     
     const majorApplies = version.major === this.targetVersion.major;
     const minorApplies = version.minor === this.targetVersion.minor;
@@ -73,7 +73,7 @@ export default class AbstractMigrator {
     await this._doWork(args);
     
     // Update world system version. 
-    WorldSystemVersion.version = this.migratedVersion;
+    await WorldSystemVersion.set(this.migratedVersion);
   }
   
   /**

--- a/business/migration/migrator-initiator.mjs
+++ b/business/migration/migrator-initiator.mjs
@@ -12,6 +12,8 @@ import Migrator_1_4_1__1_5_0 from './migrators/migrator_1-4-1_1-5-0.mjs';
 import Migrator_1_5_0__1_5_1 from './migrators/migrator_1-5-0_1-5-1.mjs';
 import './migrators/migrator_1-5-1_1-5-2.mjs';
 import './migrators/migrator_1-5-2_1-5-3.mjs';
+import './migrators/migrator_1-5-3_1-5-4.mjs';
+import './migrators/migrator_1-5-4_1-5-5.mjs';
 // Other imports. 
 import VersionCode from './version-code.mjs';
 

--- a/business/migration/migrator-initiator.mjs
+++ b/business/migration/migrator-initiator.mjs
@@ -1,15 +1,15 @@
 import { MIGRATORS } from './migrators.mjs';
 // Imports for the migrators, to populate the `MIGRATORS` list. 
-import Migrator_0_3_0__0_3_1 from './migrators/migrator_0-3-0_0-3-1.mjs';
-import Migrator_0_3_1__1_0_0 from './migrators/migrator_0-3-1_1-0-0.mjs';
-import Migrator_1_0_0__1_1_0 from './migrators/migrator_1-0-0_1-1-0.mjs';
-import Migrator_1_1_0__1_2_2 from './migrators/migrator_1-1-0_1-2-2.mjs';
-import Migrator_1_2_2__1_3_0 from './migrators/migrator_1-2-2_1-3-0.mjs';
-import Migrator_1_3_0__1_3_1 from './migrators/migrator_1-3-0_1-3-1.mjs';
-import Migrator_1_3_1__1_3_2 from './migrators/migrator_1-3-1_1-3-2.mjs';
-import Migrator_1_3_2__1_4_1 from './migrators/migrator_1-3-2_1-4-1.mjs';
-import Migrator_1_4_1__1_5_0 from './migrators/migrator_1-4-1_1-5-0.mjs';
-import Migrator_1_5_0__1_5_1 from './migrators/migrator_1-5-0_1-5-1.mjs';
+import './migrators/migrator_0-3-0_0-3-1.mjs';
+import './migrators/migrator_0-3-1_1-0-0.mjs';
+import './migrators/migrator_1-0-0_1-1-0.mjs';
+import './migrators/migrator_1-1-0_1-2-2.mjs';
+import './migrators/migrator_1-2-2_1-3-0.mjs';
+import './migrators/migrator_1-3-0_1-3-1.mjs';
+import './migrators/migrator_1-3-1_1-3-2.mjs';
+import './migrators/migrator_1-3-2_1-4-1.mjs';
+import './migrators/migrator_1-4-1_1-5-0.mjs';
+import './migrators/migrator_1-5-0_1-5-1.mjs';
 import './migrators/migrator_1-5-1_1-5-2.mjs';
 import './migrators/migrator_1-5-2_1-5-3.mjs';
 import './migrators/migrator_1-5-3_1-5-4.mjs';

--- a/business/migration/world-system-version.mjs
+++ b/business/migration/world-system-version.mjs
@@ -34,38 +34,28 @@ class WorldSystemVersionType {
   get _settingName() { return "worldSystemVersion"; }
 
   /**
-   * Gets the version represented by this object. 
-   * @type {VersionCode}
-   */
-  get version() { return this._get(); }
-  /**
-   * Sets the version represented by this object. 
-   * 
-   * **IMPORTANT**: This automatically sets the 
-   * @param {VersionCode} value
-   */
-  set version(value) { this._set(value); }
-
-  /**
    * Sets and persists the given version as the world system version. 
+   * 
    * @param {VersionCode} version The version to set. 
+   * 
+   * @async
    */
-  _set(version) {
+  async set(version) {
     this._ensureSetting();
 
     // Set the world system version.
-    game.settings.set(this._settingNamespace, this._settingKey, version.toString()); 
+    await game.settings.set(this._settingNamespace, this._settingKey, version.toString()); 
   }
 
   /**
    * Returns the world system version. 
+   * 
    * @returns {VersionCode}
-   * @private
    */
-  _get() {
+  get() {
     this._ensureSetting();
-
     const worldSystemVersion = game.settings.get(this._settingNamespace, this._settingKey); 
+    
     return VersionCode.fromString(worldSystemVersion);
   }
 

--- a/presentation/dialog/migrator-dialog/migrator-dialog.hbs
+++ b/presentation/dialog/migrator-dialog/migrator-dialog.hbs
@@ -8,8 +8,9 @@
 		<p class="hint-card info"><i class="fas fa-question-circle"></i> {{localize "ambersteel.migration.cancelNote"}}</p>
     <div class="flex-grow"></div>
 		<div class="flex flex-row">
-			<button id="confirm" class="button">{{localize "ambersteel.general.confirm"}}</button>
-			<button id="cancel" class="button">{{localize "ambersteel.general.cancel"}}</button>
+			<button id="confirm" class="button pad-l-md pad-r-md primary-button">{{localize "ambersteel.general.confirm"}}</button>
+			<span class="width-xs"></span>
+			<button id="cancel" class="button pad-l-md pad-r-md secondary-button">{{localize "ambersteel.general.cancel"}}</button>
 		</div>
 	</div>
 	{{!-- Progress screen --}}

--- a/presentation/dialog/migrator-dialog/migrator-dialog.hbs
+++ b/presentation/dialog/migrator-dialog/migrator-dialog.hbs
@@ -33,6 +33,6 @@
 		<h2 class="hint-card success"><i class="fas fa-check-circle"></i> {{localize "ambersteel.migration.completion"}}</h2>
 		<p class="hint-card success cohesive">{{localize "ambersteel.migration.completionHint"}}</p>
     <div class="flex-grow"></div>
-		<button id="ok" class="button">{{localize "ambersteel.general.ok"}}</button>
+		<button id="ok" class="button pad-l-md pad-r-md primary-button">{{localize "ambersteel.general.ok"}}</button>
 	</div>
 </section>

--- a/presentation/dialog/migrator-dialog/migrator-dialog.mjs
+++ b/presentation/dialog/migrator-dialog/migrator-dialog.mjs
@@ -48,7 +48,7 @@ export default class MigratorDialog extends ModalDialog {
 
     this.migrator = new MigratorInitiator();
 
-    this.worldVersionString = WorldSystemVersion.version.toString();
+    this.worldVersionString = WorldSystemVersion.get().toString();
     this.worldVersionMigratedString = this.migrator.finalMigrationVersion.toString();
   }
 

--- a/test/business/migration/migrator-initiator-test.mjs
+++ b/test/business/migration/migrator-initiator-test.mjs
@@ -1,0 +1,118 @@
+import should from 'should';
+import sinon from 'sinon';
+import 'should-sinon';
+import MigratorInitiator from '../../../business/migration/migrator-initiator.mjs';
+import { WorldSystemVersion } from '../../../business/migration/world-system-version.mjs';
+import VersionCode from '../../../business/migration/version-code.mjs';
+import * as MigratorTestBase from './migrators/migrator-test-base.mjs';
+import { BaseLoggingStrategy } from '../../../business/logging/base-logging-strategy.mjs';
+
+/**
+ * Mocks the active and world system versions. 
+ * 
+ * @param {String} worldVersion The faked world system version.
+ * * E.g. `"1.5.3"`
+ * @param {String} systemVersion The faked active system version. 
+ * * E.g. `"1.5.5"`
+ */
+function _mockVersions(worldVersion, systemVersion) {
+  globalThis.game.system._worldVersion = worldVersion;
+  globalThis.game.system.version = systemVersion;
+}
+
+describe("MigratorInitiator", () => {
+  before((done) => {
+    globalThis.game = {
+      settings: {
+        get: (namespace, key) => {
+          if (namespace === WorldSystemVersion._settingNamespace && key === WorldSystemVersion._settingKey) {
+            return globalThis.game.system._worldVersion;
+          }
+        },
+        set: (namespace, key, value) => {
+          if (namespace === WorldSystemVersion._settingNamespace && key === WorldSystemVersion._settingKey) {
+            globalThis.game.system._worldVersion = value;
+          }
+        },
+        register: sinon.fake(),
+      },
+      system: {
+        _worldVersion: "0.0.0",
+      },
+      actors: MigratorTestBase.createMockWorldCollection("Actor"),
+      packs: MigratorTestBase.createMockWorldCollection("Pack"),
+      items: MigratorTestBase.createMockWorldCollection("Item"),
+      journal: MigratorTestBase.createMockWorldCollection("Journal"),
+      tables: MigratorTestBase.createMockWorldCollection("RollTable"),
+      ambersteel: {
+        logger: sinon.createStubInstance(BaseLoggingStrategy),
+      },
+    };
+
+    sinon.spy(globalThis.game.settings, ["set"]);
+
+    done();
+  });
+
+  after((done) => {
+    globalThis.game = null;
+    globalThis.game = undefined;
+
+    done();
+  });
+
+  it("is applicable with world system version 1.5.3 and active version 1.5.5", () => {
+    // Setup
+    _mockVersions("1.5.3", "1.5.5");
+    
+    // Given
+    const given = new MigratorInitiator();
+
+    // When
+    const r = given.isApplicable();
+
+     // Then
+     r.should.be.eql(true);
+  });
+
+  it("is NOT applicable with world system version 1.5.5 and active version 1.5.5", () => {
+    // Setup
+    _mockVersions("1.5.5", "1.5.5");
+    
+    // Given
+    const given = new MigratorInitiator();
+
+    // When
+    const r = given.isApplicable();
+
+     // Then
+     r.should.be.eql(false);
+  });
+
+  it("migrates from 1.5.3 up to 1.5.5 in one go", async () => {
+    // Setup
+    _mockVersions("1.5.3", "1.5.5");
+
+    // Given
+    const given = new MigratorInitiator();
+
+    // When
+    const finalMigrationVersion = given.finalMigrationVersion;
+    await given.migrateAsPossible();
+
+    // Then
+    finalMigrationVersion.should.be.deepEqual(new VersionCode(1, 5, 5));
+
+    globalThis.game.settings.set.should.have.been.calledTwice();
+    globalThis.game.settings.set.should.have.been.calledWith(
+      WorldSystemVersion._settingNamespace,
+      WorldSystemVersion._settingKey,
+      "1.5.4"
+    );
+    globalThis.game.settings.set.should.have.been.calledWith(
+      WorldSystemVersion._settingNamespace,
+      WorldSystemVersion._settingKey,
+      "1.5.5"
+    );
+  });
+});

--- a/test/business/migration/migrators/migrator_1-3-2_1-4-1-test.mjs
+++ b/test/business/migration/migrators/migrator_1-3-2_1-4-1-test.mjs
@@ -219,7 +219,7 @@ describe("Migrator_1_3_2__1_4_1", () => {
     // When
     await given.migrate();
     // Then
-    WorldSystemVersion.version.should.deepEqual(new VersionCode(1, 4, 1))
+    WorldSystemVersion.get().should.deepEqual(new VersionCode(1, 4, 1))
 
     game.actors.get(actorId0).update.should.not.have.been.called();
     

--- a/test/business/migration/migrators/migrator_1-4-1_1-5-0-test.mjs
+++ b/test/business/migration/migrators/migrator_1-4-1_1-5-0-test.mjs
@@ -23,6 +23,6 @@ describe("Migrator_1_4_1__1_5_0", () => {
     // When
     await given.migrate();
     // Then
-    WorldSystemVersion.version.should.deepEqual(new VersionCode(1, 5, 0))
+    WorldSystemVersion.get().should.deepEqual(new VersionCode(1, 5, 0))
   });
 });

--- a/test/business/migration/migrators/migrator_1-5-0_1-5-1-test.mjs
+++ b/test/business/migration/migrators/migrator_1-5-0_1-5-1-test.mjs
@@ -23,6 +23,6 @@ describe("Migrator_1_5_0__1_5_1", () => {
     // When
     await given.migrate();
     // Then
-    WorldSystemVersion.version.should.deepEqual(new VersionCode(1, 5, 1))
+    WorldSystemVersion.get().should.deepEqual(new VersionCode(1, 5, 1))
   });
 });

--- a/test/business/migration/migrators/migrator_1-5-3_1-5-4-test.mjs
+++ b/test/business/migration/migrators/migrator_1-5-3_1-5-4-test.mjs
@@ -23,6 +23,6 @@ describe("Migrator_1_5_3__1_5_4", () => {
     // When
     await given.migrate();
     // Then
-    WorldSystemVersion.version.should.deepEqual(new VersionCode(1, 5, 4))
+    WorldSystemVersion.get().should.deepEqual(new VersionCode(1, 5, 4))
   });
 });

--- a/test/business/migration/migrators/migrator_1-5-4_1-5-5-test.mjs
+++ b/test/business/migration/migrators/migrator_1-5-4_1-5-5-test.mjs
@@ -370,7 +370,7 @@ describe("Migrator_1_5_4__1_5_5", () => {
     // When
     await given.migrate();
     // Then
-    WorldSystemVersion.version.should.deepEqual(new VersionCode(1, 5, 5))
+    WorldSystemVersion.get().should.deepEqual(new VersionCode(1, 5, 5))
 
     game.actors.get(actorIdPlain).update.should.not.have.been.called();
     


### PR DESCRIPTION
Closes #320 

API corrections
* Setting the world system version is actually an asynchronous task (which makes sense, considering it is a disk write operation) and must thus be awaited. For this, the API of `WorldSystemVersion` had to be changed. Its `version` property has been removed, in favor of `get` and `set` methods. The `set` method is asynchronous, while the `get` is synchronous.
* A new unit test for the `MigratorInitiator` ensures the behavior works as intended.

UI corrections
* Styling of buttons adjusted for improved readability. 