### PR TITLE
fix: Active base attribute now properly coerced

### DIFF
--- a/business/document/item/skill/transient-skill.mjs
+++ b/business/document/item/skill/transient-skill.mjs
@@ -103,7 +103,17 @@ export default class TransientSkill extends TransientBaseItem {
    * @type {Attribute}
    */
   get activeBaseAttribute() {
-    return ((ATTRIBUTES[this.document.system.activeBaseAttribute]) ?? this.baseAttributes[0]);
+    const systemActiveBaseAttribute = this.document.system.activeBaseAttribute;
+    const containedInBaseAttributes = (this.baseAttributes.find(it => it.name === systemActiveBaseAttribute) !== undefined);
+    
+    if (containedInBaseAttributes === true) {
+      return ATTRIBUTES[systemActiveBaseAttribute];
+    } else if (this.baseAttributes.length > 0) {
+      return this.baseAttributes[0];
+    } else {
+      game.ambersteel.logger.logWarn(`List of base attributes is empty for skill '${this.id}' - '${this.name}'`);
+      return ATTRIBUTES.agility;
+    }
   }
   /**
    * @param {Attribute} value


### PR DESCRIPTION
* Some skills may have an illegal active attribute defined in the pack. While that must obviously be fixed a new skill may still cause problems, regardless of a potential correction of the pack.

Closes #457 