### PR TITLE
Issue/629: feature: Moved drivers reminders to section titles

### DIFF
--- a/presentation/sheet/actor/part/abilities/actor-abilities-viewmodel.mjs
+++ b/presentation/sheet/actor/part/abilities/actor-abilities-viewmodel.mjs
@@ -1,7 +1,6 @@
 import { DerivedAttributeRollData, DerivedAttributeRollSchema } from "../../../../../business/dice/ability-roll/derived-attribute-roll-schema.mjs"
 import TransientBaseCharacterActor from "../../../../../business/document/actor/transient-base-character-actor.mjs"
 import RulesetExplainer from "../../../../../business/ruleset/ruleset-explainer.mjs"
-import GameSystemUserSettings from "../../../../../business/setting/game-system-user-settings.mjs"
 import { ValidationUtil } from "../../../../../business/util/validation-utility.mjs"
 import { ExtenderUtil } from "../../../../../common/extender-util.mjs"
 import ButtonRollViewModel from "../../../../component/button-roll/button-roll-viewmodel.mjs"
@@ -44,12 +43,6 @@ export default class ActorAbilitiesViewModel extends ViewModel {
    * @readonly
    */
   get isInCombat() { return this.document.document.inCombat; }
-  
-  /**
-   * @type {Boolean}
-   * @readonly
-   */
-  get showReminders() { return new GameSystemUserSettings().get(GameSystemUserSettings.KEY_TOGGLE_REMINDERS); }
   
   /**
    * @type {Boolean}

--- a/presentation/sheet/actor/part/health/actor-health-states-viewmodel.mjs
+++ b/presentation/sheet/actor/part/health/actor-health-states-viewmodel.mjs
@@ -104,7 +104,6 @@ export default class ActorHealthStatesViewModel extends ViewModel {
       }
     });
 
-    const showReminders = new GameSystemUserSettings().get(GameSystemUserSettings.KEY_TOGGLE_REMINDERS);
     for (const state of states) {
       const isVisible = stateSettings.hidden.find(stateName => state.name === stateName) === undefined;
       if (isVisible === true) {
@@ -116,7 +115,7 @@ export default class ActorHealthStatesViewModel extends ViewModel {
           isSendable: this.isSendable,
           isOwner: this.isOwner,
           localizedLabel: game.i18n.localize(state.localizableName),
-          localizedToolTip: showReminders ? game.i18n.localize(state.localizableToolTip) : undefined,
+          localizedToolTip: this.showReminders ? game.i18n.localize(state.localizableToolTip) : undefined,
           stateName: state.name,
           stateIntensity: state.intensity,
           stateLimit: state.limit,

--- a/presentation/sheet/actor/part/health/actor-health-viewmodel.mjs
+++ b/presentation/sheet/actor/part/health/actor-health-viewmodel.mjs
@@ -7,7 +7,6 @@ import { ITEM_TYPES } from "../../../../../business/document/item/item-types.mjs
 import { ATTRIBUTES } from "../../../../../business/ruleset/attribute/attributes.mjs"
 import RulesetExplainer from "../../../../../business/ruleset/ruleset-explainer.mjs"
 import { Sum, SumComponent } from "../../../../../business/ruleset/summed-data.mjs"
-import GameSystemUserSettings from "../../../../../business/setting/game-system-user-settings.mjs"
 import { StringUtil } from "../../../../../business/util/string-utility.mjs"
 import { ValidationUtil } from "../../../../../business/util/validation-utility.mjs"
 import { ExtenderUtil } from "../../../../../common/extender-util.mjs"
@@ -91,12 +90,6 @@ export default class ActorHealthViewModel extends ViewModel {
    * @readonly
    */
   get maxExhaustion() { return this.document.health.maxExhaustion; }
-
-  /**
-   * @type {boolean}
-   * @readonly
-   */
-  get showReminders() { return new GameSystemUserSettings().get(GameSystemUserSettings.KEY_TOGGLE_REMINDERS); }
 
   /**
    * @type {Array<IllnessListItemViewModel>}

--- a/presentation/sheet/actor/part/personality/actor-drivers-viewmodel.mjs
+++ b/presentation/sheet/actor/part/personality/actor-drivers-viewmodel.mjs
@@ -1,3 +1,4 @@
+import GameSystemUserSettings from "../../../../../business/setting/game-system-user-settings.mjs";
 import { ValidationUtil } from "../../../../../business/util/validation-utility.mjs";
 import { ExtenderUtil } from "../../../../../common/extender-util.mjs";
 import InputTextFieldViewModel from "../../../../component/input-textfield/input-textfield-viewmodel.mjs";
@@ -61,18 +62,22 @@ export default class ActorDriversViewModel extends ViewModel {
     this.document = args.document;
     this.contextType = args.contextType ?? "actor-drivers";
 
-    const thiz = this;
-
     this.vmTfAmbition = new InputTextFieldViewModel({
-      parent: thiz,
+      parent: this,
       id: "vmTfAmbition",
-      value: thiz.document.driverSystem.ambition,
+      value: this.document.driverSystem.ambition,
       placeholder: game.i18n.localize("system.character.driverSystem.ambition.placeholder"),
-      localizedToolTip: game.i18n.localize("system.character.driverSystem.ambition.reminder"),
       onChange: (_, newValue) => {
-        thiz.document.driverSystem.ambition = newValue;
+        this.document.driverSystem.ambition = newValue;
       },
     });
+    if (this.showReminders) {
+      this.vmAmbitionReminder = new ViewModel({
+        id: "vmAmbitionReminder",
+        parent: this,
+        localizedToolTip: game.i18n.localize("system.character.driverSystem.ambition.reminder"),
+      })
+    }
 
     const aspirationPlaceholders = [
       "system.character.driverSystem.aspiration.placeholder.1",
@@ -81,15 +86,21 @@ export default class ActorDriversViewModel extends ViewModel {
     ];
     for (let i = 0; i < this.aspirations.length; i++) {
       this.aspirationViewModels.push(new InputTextFieldViewModel({
-        parent: thiz,
+        parent: this,
         id: `vmAspiration-${i}`,
-        value: thiz.document.driverSystem.aspirations[`_${i}`],
+        value: this.document.driverSystem.aspirations[`_${i}`],
         placeholder: game.i18n.localize(aspirationPlaceholders[i]),
-        localizedToolTip: game.i18n.localize("system.character.driverSystem.aspiration.reminder"),
         onChange: (_, newValue) => {
-          thiz.document.driverSystem.aspirations[`_${i}`] = newValue;
+          this.document.driverSystem.aspirations[`_${i}`] = newValue;
         },
       }));
+    }
+    if (this.showReminders) {
+      this.vmAspirationReminder = new ViewModel({
+        id: "vmAspirationReminder",
+        parent: this,
+        localizedToolTip: game.i18n.localize("system.character.driverSystem.aspiration.reminder"),
+      })
     }
 
     const reactionPlaceholders = [
@@ -99,15 +110,21 @@ export default class ActorDriversViewModel extends ViewModel {
     ];
     for (let i = 0; i < this.reactions.length; i++) {
       this.reactionViewModels.push(new InputTextFieldViewModel({
-        parent: thiz,
+        parent: this,
         id: `vmReaction-${i}`,
-        value: thiz.document.driverSystem.reactions[`_${i}`],
+        value: this.document.driverSystem.reactions[`_${i}`],
         placeholder: game.i18n.localize(reactionPlaceholders[i]),
-        localizedToolTip: game.i18n.localize("system.character.driverSystem.reaction.reminder"),
         onChange: (_, newValue) => {
-          thiz.document.driverSystem.reactions[`_${i}`] = newValue;
+          this.document.driverSystem.reactions[`_${i}`] = newValue;
         },
       }));
+    }
+    if (this.showReminders) {
+      this.vmReactionReminder = new ViewModel({
+        id: "vmReactionReminder",
+        parent: this,
+        localizedToolTip: game.i18n.localize("system.character.driverSystem.reaction.reminder"),
+      })
     }
   }
     

--- a/presentation/sheet/actor/part/personality/actor-drivers.hbs
+++ b/presentation/sheet/actor/part/personality/actor-drivers.hbs
@@ -3,17 +3,41 @@ viewModel: {ActorDriversViewModel}
 cssClass: {undefined | String}
 --}}
 <section id="{{viewModel.id}}" class="{{cssClass}}">
-  {{#> header3 showFancyFont=viewModel.showFancyFont}}{{localize "system.character.driverSystem.ambition.header"}}{{/header3}}
+  <h3 class="strive-header flex flex-row{{#if viewModel.showFancyFont}} fancy-font{{/if}}">
+    {{!-- Reminder --}}
+    {{#if viewModel.showReminders}}
+    <span class="button light square font-size-default flex flex-center" id="{{viewModel.vmAmbitionReminder.id}}">
+      <i class="far fa-question-circle info-button"></i>
+    </span>
+    {{/if}}
+    <span>{{localize "system.character.driverSystem.ambition.header"}}</span>
+  </h3>
   <div class="margin-b-md">
     {{> inputTextField viewModel=viewModel.vmTfAmbition }}
   </div>
-  {{#> header3 showFancyFont=viewModel.showFancyFont}}{{localize "system.character.driverSystem.aspiration.header"}}{{/header3}}
+  <h3 class="strive-header flex flex-row{{#if viewModel.showFancyFont}} fancy-font{{/if}}">
+    {{!-- Reminder --}}
+    {{#if viewModel.showReminders}}
+    <span class="button light square font-size-default flex flex-center" id="{{viewModel.vmAspirationReminder.id}}">
+      <i class="far fa-question-circle info-button"></i>
+    </span>
+    {{/if}}
+    <span>{{localize "system.character.driverSystem.aspiration.header"}}</span>
+  </h3>
   {{#each viewModel.aspirationViewModels as |vm index|}}
     <div class="margin-b-md">
       {{> inputTextField viewModel=vm}}
     </div>
   {{/each}}
-  {{#> header3 showFancyFont=viewModel.showFancyFont}}{{localize "system.character.driverSystem.reaction.header"}}{{/header3}}
+  <h3 class="strive-header flex flex-row{{#if viewModel.showFancyFont}} fancy-font{{/if}}">
+    {{!-- Reminder --}}
+    {{#if viewModel.showReminders}}
+    <span class="button light square font-size-default flex flex-center" id="{{viewModel.vmReactionReminder.id}}">
+      <i class="far fa-question-circle info-button"></i>
+    </span>
+    {{/if}}
+    <span>{{localize "system.character.driverSystem.reaction.header"}}</span>
+  </h3>
   {{#each viewModel.reactionViewModels as |vm index|}}
     <div class="margin-b-md">
       {{> inputTextField viewModel=vm}}

--- a/presentation/view-model/view-model.mjs
+++ b/presentation/view-model/view-model.mjs
@@ -1,3 +1,4 @@
+import GameSystemUserSettings from "../../business/setting/game-system-user-settings.mjs";
 import GetShowFancyFontUseCase from "../../business/use-case/get-show-fancy-font-use-case.mjs";
 import { PropertyUtil } from "../../business/util/property-utility.mjs";
 import { UuidUtil } from "../../business/util/uuid-utility.mjs";
@@ -281,6 +282,14 @@ export default class ViewModel {
   set showFancyFont(value) {
     this._showFancyFont = value;
   }
+
+  /**
+   * Returns true, if rule reminders are enabled. 
+   * 
+   * @type {Boolean}
+   * @readonly
+   */
+  get showReminders() { return new GameSystemUserSettings().get(GameSystemUserSettings.KEY_TOGGLE_REMINDERS); }
 
   /**
    * Name or path of a contextual template, which will be displayed in exception log entries, to aid debugging. 


### PR DESCRIPTION
* And took the opportunity to move the `showReminders` property to the base `ViewModel`, so all view model instances can access it right away.

Closes #629 