### PR TITLE
Issue/717: fix: Sortable list filter

### DIFF
--- a/presentation/component/sortable-list/sortable-list-viewmodel.mjs
+++ b/presentation/component/sortable-list/sortable-list-viewmodel.mjs
@@ -32,7 +32,7 @@ export default class SortableListViewModel extends ViewModel {
    * @readonly
    * @private
    */
-  static CSS_SELECTOR_LIST_ITEMS = "ol.sortable-list > li";
+  static CSS_SELECTOR_LIST_ITEMS = "> li";
 
   /**
    * This is a list of `entityId`s, in the order that they should be rendered in the list. 


### PR DESCRIPTION
* It can now correctly detect its list items again. After the refactor wherein the wrapping element was removed, the `CSS_SELECTOR_LIST_ITEMS` was forgotten to update, as well.

Closes #717 