### PR TITLE
Issue/716: fix: HP tool tip

### DIFF
--- a/presentation/lang/en.json
+++ b/presentation/lang/en.json
@@ -501,7 +501,7 @@
         "singular": "Grit Point",
         "plural": "Grit Points",
         "toggleLabel": "Enable Grit Points",
-        "tooltip": "A Grit Point lets a character stand up in defiance of their injuries and make a last-ditch effort to turn the wheel of fate around. Every time a character suffers an injury, they gain <code>1</code> Grit Point. <br><br>Grit Points are one-time use and last until they are spent or until an injury has fully healed. <br><br>You may spend Grit Points at any time during a round for the following effects (but only one Grit Point per effect, per round): <ul><li>On a test, gain <code>+2D</code>.</li><li>On a test, gain <code>+1</code> compensation point.</li><li>Reduce exhaustion by <code>1D4</code>.</li><li>On your attack, deal <code>+8</code> points of pure damage.</li><li>Gain <code>+1D4</code> AP.</li></ul>"
+        "tooltip": "A Grit Point lets a character stand up in defiance of their injuries and make a last-ditch effort to turn the wheel of fate around. Every time a character suffers an Injury, they gain <code>1</code> Grit Point. <br><br>Grit Points are one-time use and last until they are spent or until an Injury has fully healed. <br><br>You may spend Grit Points at any time during a round for the following effects (but only one Grit Point per effect, per round): <ul><li>On a test, gain <code>+2D</code>.</li><li>On a test, gain <code>+1</code> compensation point.</li><li>Reduce exhaustion by <code>1D4</code>.</li><li>On your attack, deal <code>+8</code> points of pure damage.</li><li>Gain <code>+1D4</code> AP.</li></ul>"
       },
       "health": {
         "duration": "Duration",
@@ -542,7 +542,7 @@
           "adjust": "Adjust HP",
           "adjustInputLabel": "HP to add/subtract",
           "maxWithModifier": "Maximum Hit-Points (Max. HP)<br>%{maximum} %{operand} %{modifier} (modifier) = %{finalValue}",
-          "maxExplanation": "%{baseHp} (base) + (%{toughness} (toughness) * %{hpPerLevel}) = %{unmodifiedHp} (Maximum HP)<br>%{unmodifiedHp} (Maximum HP) - (%{injuryCount} (injury count) * %{hpReductionPerInjury} (reduction per injury)) %{operand} %{modifier} (modifier) = %{finalMaxHp}"
+          "maxExplanation": "%{baseHp} (base) + (%{toughness} (toughness) * %{hpPerLevel}) = %{unmodifiedHp} (Maximum HP)<br>%{unmodifiedHp} (Maximum HP) - (%{injuryCount} (Injury count) * %{hpReductionPerInjury} (reduction per Injury)) %{operand} %{modifier} (modifier) = %{finalMaxHp}"
         },
         "illness": {
           "plural": "Illnesses",
@@ -592,9 +592,9 @@
           "shrugOff": {
             "count": "Number of shrug-offs",
             "roll": "Roll for a shrug-off test",
-            "chatMessage": "Rolls to shrug off an injury"
+            "chatMessage": "Rolls to shrug off an Injury"
           },
-          "reminder": "A loss of <code>10+</code> HP may result in an injury.<br>A loss of <code>20+</code> HP may result in two injuries.<br>A shrug-off test will determine whether you actually suffer any injury."
+          "reminder": "Every time HP drop below an increment of <code>10</code>, an Injury might be suffered. For example, when dropping from <code>40</code> to <code>39</code>.<br>A shrug-off test will determine whether you actually suffer any Injury.<br>At most <code>2</code> Injuries can be suffered from a single source of damage."
         },
         "mutation": {
           "plural": "Mutations",


### PR DESCRIPTION
* Now more accurately outlines the rules for Injury suffering.
* Also took the opportunity to consolidate the spelling of the game mechanical term `Injury`. It is now treated as a noun.

Closes #716 